### PR TITLE
Ocultar botones administrativos en el catálogo público

### DIFF
--- a/src/modules/catalog/catalog.css
+++ b/src/modules/catalog/catalog.css
@@ -155,10 +155,6 @@
     gap: 10px;
 }
 
-.admin-only {
-    display: none;
-}
-
 .btn-add-cart {
     flex: 1;
     background: var(--success);

--- a/src/modules/catalog/catalog.css
+++ b/src/modules/catalog/catalog.css
@@ -155,6 +155,10 @@
     gap: 10px;
 }
 
+.admin-only {
+    display: none;
+}
+
 .btn-add-cart {
     flex: 1;
     background: var(--success);

--- a/src/modules/catalog/catalog.js
+++ b/src/modules/catalog/catalog.js
@@ -329,6 +329,12 @@ function closeModal(id) {
 function renderProductCard(product) {
     const stockClass = product.stock === 0 ? 'out' : product.stock < 5 ? 'low' : '';
     const imageStyle = product.image ? `style="background-image: url('${product.image}')" class="product-image has-image"` : 'class="product-image"';
+    const adminActions = state.isAdmin
+        ? `
+                    <button class="btn-edit admin-only" data-action="edit-product" data-id="${product.id}">✏️</button>
+                    <button class="btn-delete admin-only" data-action="delete-product" data-id="${product.id}">🗑️</button>`
+        : '';
+
     return `
         <div class="product-card">
             <div ${imageStyle}>${product.image ? '' : '🛍️'}</div>
@@ -340,8 +346,7 @@ function renderProductCard(product) {
                 <span class="product-stock ${stockClass}">Stock: ${product.stock}</span>
                 <div class="product-actions">
                     <button class="btn-add-cart" data-action="add-to-cart" data-id="${product.id}" ${product.stock === 0 ? 'disabled' : ''}>Agregar</button>
-                    <button class="btn-edit admin-only" data-action="edit-product" data-id="${product.id}">✏️</button>
-                    <button class="btn-delete admin-only" data-action="delete-product" data-id="${product.id}">🗑️</button>
+                    ${adminActions}
                 </div>
             </div>
         </div>`;


### PR DESCRIPTION
## Summary
- agrega una regla CSS para ocultar los elementos con clase `admin-only` en el catálogo público.
- mantiene la visibilidad de estas acciones únicamente cuando el modo administrador esté activo.

## Testing
- No se realizaron pruebas automatizadas (no aplicable).


------
https://chatgpt.com/codex/tasks/task_e_68e3e81a2184832dbb18e15aea2acc86