### PR TITLE
Add configurable chatbot to client portal

### DIFF
--- a/client-portal.html
+++ b/client-portal.html
@@ -94,6 +94,39 @@
                 <li>No hay condiciones registradas para este portal.</li>
             </ul>
         </section>
+        <div class="client-portal-chatbot hidden" data-chatbot-container data-chatbot-active="false">
+            <button type="button" class="client-portal-chatbot-toggle" data-chatbot-toggle aria-controls="clientChatbotWindow" aria-expanded="false">
+                <span aria-hidden="true">💬</span>
+                <span class="sr-only">Abrir asistente virtual</span>
+            </button>
+            <section
+                class="client-portal-chatbot-window"
+                id="clientChatbotWindow"
+                data-chatbot-window
+                role="dialog"
+                aria-modal="false"
+                aria-labelledby="clientChatbotTitle"
+                hidden
+            >
+                <header class="client-portal-chatbot-header">
+                    <div>
+                        <h2 class="client-portal-chatbot-title" id="clientChatbotTitle" data-chatbot-title>Asistente virtual</h2>
+                        <p class="client-portal-chatbot-subtitle" data-chatbot-subtitle>Resolvemos tus dudas al instante.</p>
+                    </div>
+                    <button type="button" class="client-portal-chatbot-close" data-chatbot-close aria-label="Cerrar asistente">&times;</button>
+                </header>
+                <div class="client-portal-chatbot-body">
+                    <div class="client-portal-chatbot-messages" id="clientChatbotMessages" aria-live="polite"></div>
+                    <div class="client-portal-chatbot-typing" data-chatbot-typing>El asistente está escribiendo…</div>
+                </div>
+                <div class="client-portal-chatbot-quick hidden" id="clientChatbotQuick" aria-hidden="true" aria-label="Preguntas sugeridas"></div>
+                <form class="client-portal-chatbot-form" id="clientChatbotForm" autocomplete="off">
+                    <label class="sr-only" for="clientChatbotInput">Escribe tu mensaje</label>
+                    <input type="text" id="clientChatbotInput" name="message" placeholder="Escribe tu pregunta..." autocomplete="off" />
+                    <button type="submit" class="client-portal-chatbot-send">Enviar</button>
+                </form>
+            </section>
+        </div>
     </main>
 
     <script type="module" src="src/clientCatalog.js"></script>

--- a/index.html
+++ b/index.html
@@ -582,6 +582,31 @@
                             <span class="field-note">Incluye <code>{{slug}}</code> para insertar el identificador del portal en la liga que compartirás; si lo omites se añadirá automáticamente como parámetro <code>?portal=</code>.</span>
                         </label>
                     </div>
+                    <fieldset class="settings-chatbot">
+                        <legend>Chatbot para el portal de clientes</legend>
+                        <p class="settings-chatbot-hint">Activa un asistente virtual que responderá preguntas frecuentes desde el portal público.</p>
+                        <label class="settings-form-field settings-chatbot-toggle">
+                            <span>Activar chatbot</span>
+                            <input type="checkbox" name="chatbotEnabled" id="chatbotEnabled" />
+                        </label>
+                        <label class="settings-form-field">
+                            <span>Nombre del asistente</span>
+                            <input type="text" name="chatbotName" placeholder="Ej. Asistente virtual" />
+                        </label>
+                        <label class="settings-form-field wide">
+                            <span>Mensaje de bienvenida</span>
+                            <textarea name="chatbotWelcome" rows="2" placeholder="Mensaje inicial que verá el cliente"></textarea>
+                        </label>
+                        <div class="chatbot-faq-config">
+                            <header class="chatbot-faq-header">
+                                <h4>Preguntas frecuentes</h4>
+                                <p>Estas preguntas se mostrarán como accesos directos y el bot intentará reconocerlas si el cliente las escribe.</p>
+                            </header>
+                            <div class="chatbot-faq-list" id="chatbotFaqList" aria-live="polite"></div>
+                            <p class="chatbot-faq-empty" data-chatbot-empty>No has agregado preguntas frecuentes. Usa el botón para crear la primera.</p>
+                            <button type="button" class="chatbot-faq-add" id="addChatbotFaq">Agregar pregunta frecuente</button>
+                        </div>
+                    </fieldset>
                     <div class="settings-form-actions">
                         <button type="submit" class="settings-form-submit">Guardar configuración</button>
                     </div>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
 
                 <button class="form-submit" type="submit">Entrar</button>
                 <p class="form-feedback" role="status" data-feedback-for="login"></p>
+                <p class="auth-switch" data-auth-context="login">
+                    ¿No tienes cuenta?
+                    <button class="auth-switch-link" type="button" data-auth-switch="register">Crea una aquí</button>
+                </p>
             </form>
 
             <form id="registerForm" class="auth-form hidden" autocomplete="on">
@@ -42,6 +46,10 @@
 
                 <button class="form-submit" type="submit">Crear cuenta</button>
                 <p class="form-feedback" role="status" data-feedback-for="register"></p>
+                <p class="auth-switch" data-auth-context="register">
+                    ¿Ya tienes una cuenta?
+                    <button class="auth-switch-link" type="button" data-auth-switch="login">Inicia sesión</button>
+                </p>
             </form>
         </section>
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,3 +1,6 @@
+const LOCAL_USER_STORAGE_KEY = 'catalogoLocalUsers';
+const LOCAL_SESSION_STORAGE_KEY = 'catalogoLocalSession';
+
 const formSelectors = {
     login: {
         form: '#loginForm',
@@ -10,6 +13,216 @@ const formSelectors = {
         submit: '#registerForm .form-submit'
     }
 };
+
+function getStorage() {
+    try {
+        if (typeof window !== 'undefined' && window.localStorage) {
+            return window.localStorage;
+        }
+    } catch (error) {
+        console.warn('No se puede acceder a localStorage:', error);
+    }
+    return null;
+}
+
+function readStorageJson(key, fallback) {
+    const storage = getStorage();
+    if (!storage) return fallback;
+
+    try {
+        const raw = storage.getItem(key);
+        if (!raw) return fallback;
+        return JSON.parse(raw);
+    } catch (error) {
+        console.warn(`No se pudo leer la clave ${key} de localStorage:`, error);
+        return fallback;
+    }
+}
+
+function writeStorageJson(key, value) {
+    const storage = getStorage();
+    if (!storage) return false;
+
+    try {
+        storage.setItem(key, JSON.stringify(value));
+        return true;
+    } catch (error) {
+        console.warn(`No se pudo guardar la clave ${key} en localStorage:`, error);
+        return false;
+    }
+}
+
+function bufferToHex(buffer) {
+    return Array.from(new Uint8Array(buffer))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+async function hashPassword(password) {
+    try {
+        if (typeof window !== 'undefined' && window.crypto?.subtle) {
+            const encoder = new TextEncoder();
+            const data = encoder.encode(password);
+            const hashBuffer = await window.crypto.subtle.digest('SHA-256', data);
+            return `sha256:${bufferToHex(hashBuffer)}`;
+        }
+    } catch (error) {
+        console.warn('No se pudo generar el hash de la contraseña:', error);
+    }
+
+    return `plain:${password}`;
+}
+
+function generateLocalId() {
+    if (typeof window !== 'undefined' && window.crypto?.randomUUID) {
+        return `local-${window.crypto.randomUUID()}`;
+    }
+
+    return `local-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getLocalUsers() {
+    const users = readStorageJson(LOCAL_USER_STORAGE_KEY, []);
+    if (!Array.isArray(users)) {
+        return [];
+    }
+
+    return users
+        .map((user) => {
+            if (!user || typeof user !== 'object') return null;
+            if (!user.email || !user.passwordHash) return null;
+            return {
+                id: user.id || generateLocalId(),
+                email: String(user.email).trim(),
+                passwordHash: String(user.passwordHash),
+                createdAt: user.createdAt || new Date().toISOString()
+            };
+        })
+        .filter(Boolean);
+}
+
+function saveLocalUsers(users) {
+    return writeStorageJson(LOCAL_USER_STORAGE_KEY, users);
+}
+
+async function createLocalUserAccount(email, password) {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) {
+        return { error: 'El correo es obligatorio.' };
+    }
+
+    const users = getLocalUsers();
+    if (users.some((user) => user.email.toLowerCase() === normalizedEmail)) {
+        return { error: 'Ya existe una cuenta local con este correo.' };
+    }
+
+    const passwordHash = await hashPassword(password);
+    const newUser = {
+        id: generateLocalId(),
+        email: normalizedEmail,
+        passwordHash,
+        createdAt: new Date().toISOString()
+    };
+
+    users.push(newUser);
+    if (!saveLocalUsers(users)) {
+        return { error: 'No se pudo guardar la cuenta local.' };
+    }
+
+    const session = createLocalSession(newUser);
+    return { user: newUser, session };
+}
+
+async function authenticateLocalUser(email, password) {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) {
+        return { error: 'El correo es obligatorio.' };
+    }
+
+    const users = getLocalUsers();
+    const user = users.find((item) => item.email.toLowerCase() === normalizedEmail);
+
+    if (!user) {
+        return { error: 'No existe una cuenta local con este correo.' };
+    }
+
+    const passwordHash = await hashPassword(password);
+    if (passwordHash !== user.passwordHash && `plain:${password}` !== user.passwordHash) {
+        return { error: 'La contraseña no es válida.' };
+    }
+
+    const session = createLocalSession(user);
+    return { user, session };
+}
+
+function isNetworkError(error) {
+    if (!error) return false;
+
+    if (error instanceof TypeError) {
+        return true;
+    }
+
+    if (typeof error.status === 'number' && error.status === 0) {
+        return true;
+    }
+
+    const message = String(error.message ?? error.error_description ?? '').toLowerCase();
+    if (!message) return false;
+
+    return (
+        message.includes('fetch') ||
+        message.includes('network') ||
+        message.includes('timeout') ||
+        message.includes('dns') ||
+        message.includes('offline')
+    );
+}
+
+function normalizeSessionUser(user) {
+    const createdAt = user.createdAt || user.created_at || new Date().toISOString();
+    return {
+        id: user.id || generateLocalId(),
+        email: String(user.email ?? '').trim(),
+        app_metadata: { provider: 'local' },
+        user_metadata: { localAccount: true },
+        aud: 'authenticated',
+        created_at: createdAt
+    };
+}
+
+function createLocalSession(user) {
+    const session = {
+        access_token: null,
+        expires_at: null,
+        token_type: 'local',
+        user: normalizeSessionUser(user),
+        provider_token: null,
+        isLocalSession: true
+    };
+
+    writeStorageJson(LOCAL_SESSION_STORAGE_KEY, session);
+    return session;
+}
+
+export function getStoredLocalSession() {
+    const session = readStorageJson(LOCAL_SESSION_STORAGE_KEY, null);
+    if (!session || typeof session !== 'object') {
+        return null;
+    }
+
+    if (!session.user?.email) {
+        return null;
+    }
+
+    session.isLocalSession = true;
+    session.user = normalizeSessionUser(session.user);
+    return session;
+}
+
+export function clearStoredLocalSession() {
+    const storage = getStorage();
+    storage?.removeItem(LOCAL_SESSION_STORAGE_KEY);
+}
 
 function setMessage(target, text, type = 'neutral') {
     const messageEl = document.querySelector(formSelectors[target].message);
@@ -74,11 +287,36 @@ export function initAuth({ supabase, onLoginSuccess } = {}) {
         const email = event.currentTarget.email.value.trim();
         const password = event.currentTarget.password.value;
 
-        const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+        let data = null;
+        let error = null;
+
+        try {
+            const response = await supabase.auth.signInWithPassword({ email, password });
+            data = response.data;
+            error = response.error;
+        } catch (signInError) {
+            error = signInError;
+        }
 
         if (error) {
-            setMessage('login', error.message ?? 'No se pudo iniciar sesión.', 'error');
+            const localResult = await authenticateLocalUser(email, password);
+
+            if (localResult?.session) {
+                setMessage('login', 'Inicio de sesión exitoso (modo sin conexión).', 'success');
+                if (typeof onLoginSuccess === 'function') {
+                    await onLoginSuccess(localResult.session);
+                }
+            } else if (isNetworkError(error)) {
+                setMessage(
+                    'login',
+                    'No hay conexión con Supabase y no se encontró una cuenta local para este correo.',
+                    'error'
+                );
+            } else {
+                setMessage('login', error.message ?? 'No se pudo iniciar sesión.', 'error');
+            }
         } else if (data?.session) {
+            clearStoredLocalSession();
             setMessage('login', 'Inicio de sesión exitoso. ¡Bienvenido!', 'success');
             if (typeof onLoginSuccess === 'function') {
                 await onLoginSuccess(data.session);
@@ -105,11 +343,43 @@ export function initAuth({ supabase, onLoginSuccess } = {}) {
             return;
         }
 
-        const { data, error } = await supabase.auth.signUp({ email, password });
+        let data = null;
+        let error = null;
+
+        try {
+            const response = await supabase.auth.signUp({ email, password });
+            data = response.data;
+            error = response.error;
+        } catch (signUpError) {
+            error = signUpError;
+        }
 
         if (error) {
-            setMessage('register', error.message ?? 'No se pudo crear la cuenta.', 'error');
+            if (isNetworkError(error)) {
+                const fallback = await createLocalUserAccount(email, password);
+
+                if (fallback?.session) {
+                    setMessage(
+                        'register',
+                        'Cuenta creada en modo local. Puedes iniciar sesión incluso sin conexión.',
+                        'success'
+                    );
+                    registerForm.reset();
+                    if (typeof onLoginSuccess === 'function') {
+                        await onLoginSuccess(fallback.session);
+                    }
+                } else {
+                    setMessage(
+                        'register',
+                        fallback?.error ?? 'No se pudo crear la cuenta local.',
+                        'error'
+                    );
+                }
+            } else {
+                setMessage('register', error.message ?? 'No se pudo crear la cuenta.', 'error');
+            }
         } else if (data?.user) {
+            clearStoredLocalSession();
             const requiresConfirmation = data.user.confirmation_sent_at !== null;
             const successMessage = requiresConfirmation
                 ? 'Cuenta creada. Revisa tu correo para confirmar.'

--- a/src/clientCatalog.js
+++ b/src/clientCatalog.js
@@ -4,6 +4,44 @@ let activePortal = null;
 let portalProducts = [];
 const selectedItems = new Map();
 
+function parseBooleanFlag(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'number') {
+        if (Number.isNaN(value)) {
+            return undefined;
+        }
+
+        if (value === 1) {
+            return true;
+        }
+
+        if (value === 0) {
+            return false;
+        }
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+
+        if (!normalized) {
+            return undefined;
+        }
+
+        if (['true', '1', 'yes', 'y', 'si', 'sí', 'on', 't'].includes(normalized)) {
+            return true;
+        }
+
+        if (['false', '0', 'no', 'n', 'off', 'f'].includes(normalized)) {
+            return false;
+        }
+    }
+
+    return undefined;
+}
+
 const defaultChatbotConfig = {
     enabled: false,
     name: 'Asistente virtual',
@@ -182,9 +220,13 @@ function normalizeChatbotSettingsRecords(records) {
 
         switch (key) {
             case 'chatbot_enabled':
-            case 'chatbotenabled':
-                config.enabled = rawValue === true || rawValue === 'true' || rawValue === '1';
+            case 'chatbotenabled': {
+                const parsed = parseBooleanFlag(rawValue);
+                if (typeof parsed === 'boolean') {
+                    config.enabled = parsed;
+                }
                 break;
+            }
             case 'chatbot_name':
             case 'chatbotname':
                 config.name = typeof rawValue === 'string' ? rawValue.trim() : '';
@@ -1266,14 +1308,7 @@ function normalizePortalRecord(record, slug) {
     const bannerImage = record.banner_image ?? record.bannerImage ?? record.hero_image ?? '';
 
     const rawChatbotEnabled = record.chatbot_enabled ?? record.chatbotEnabled;
-    const portalChatbotEnabled =
-        typeof rawChatbotEnabled === 'boolean'
-            ? rawChatbotEnabled
-            : rawChatbotEnabled === 'true'
-              ? true
-              : rawChatbotEnabled === 'false'
-                ? false
-                : undefined;
+    const portalChatbotEnabled = parseBooleanFlag(rawChatbotEnabled);
 
     return {
         id: record.id ?? slug,

--- a/src/clientCatalog.js
+++ b/src/clientCatalog.js
@@ -1170,7 +1170,11 @@ async function handleRequestSubmit(event) {
             quantity,
             unit_price: product.price
         })),
-        total: selections.reduce((sum, { product, quantity }) => sum + Number(product.price || 0) * quantity, 0)
+        total: selections.reduce(
+            (sum, { product, quantity }) => sum + Number(product.price || 0) * quantity,
+            0
+        ),
+        ownerId: activePortal.ownerId ?? null
     };
 
     if (!payload.name || !payload.email) {
@@ -1194,6 +1198,7 @@ async function handleRequestSubmit(event) {
                 notes: payload.notes,
                 items: payload.items,
                 total: payload.total,
+                owner_id: activePortal.ownerId ?? null,
                 submitted_at: new Date().toISOString()
             });
         if (!error) {
@@ -1280,7 +1285,8 @@ function normalizePortalRecord(record, slug) {
         productIds,
         heroVideo: record.hero_video ?? record.heroVideo ?? '',
         heroMediaType: record.hero_media_type ?? record.heroMediaType ?? '',
-        requestIntro: record.request_intro ?? record.requestIntro ?? ''
+        requestIntro: record.request_intro ?? record.requestIntro ?? '',
+        ownerId: record.owner_id ?? record.ownerId ?? null
     };
 }
 

--- a/src/clientCatalog.js
+++ b/src/clientCatalog.js
@@ -1265,6 +1265,16 @@ function normalizePortalRecord(record, slug) {
     const terms = parseArrayField(record.terms ?? record.terms_conditions ?? record.conditions);
     const bannerImage = record.banner_image ?? record.bannerImage ?? record.hero_image ?? '';
 
+    const rawChatbotEnabled = record.chatbot_enabled ?? record.chatbotEnabled;
+    const portalChatbotEnabled =
+        typeof rawChatbotEnabled === 'boolean'
+            ? rawChatbotEnabled
+            : rawChatbotEnabled === 'true'
+              ? true
+              : rawChatbotEnabled === 'false'
+                ? false
+                : undefined;
+
     return {
         id: record.id ?? slug,
         slug: record.slug ?? slug,
@@ -1277,7 +1287,7 @@ function normalizePortalRecord(record, slug) {
         contactPhone: record.contact_phone ?? record.phone ?? '',
         bannerImage,
         bannerImageUrl: resolveMediaUrl(bannerImage),
-        chatbotEnabled: Boolean(record.chatbot_enabled ?? record.chatbotEnabled ?? false),
+        chatbotEnabled: portalChatbotEnabled,
         chatbotName: record.chatbot_name ?? record.chatbotName ?? '',
         chatbotWelcome: record.chatbot_welcome ?? record.chatbotWelcome ?? '',
         chatbotFaqs: normalizeChatbotFaqs(record.chatbot_faqs ?? record.chatbotFaqs ?? []),

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -77,6 +77,44 @@ const DASHBOARD_SELECTORS = {
 };
 const defaultDashboardState = getInitialDashboardData();
 
+function parseBooleanFlag(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'number') {
+        if (Number.isNaN(value)) {
+            return undefined;
+        }
+
+        if (value === 1) {
+            return true;
+        }
+
+        if (value === 0) {
+            return false;
+        }
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+
+        if (!normalized) {
+            return undefined;
+        }
+
+        if (['true', '1', 'yes', 'y', 'si', 'sí', 'on', 't'].includes(normalized)) {
+            return true;
+        }
+
+        if (['false', '0', 'no', 'n', 'off', 'f'].includes(normalized)) {
+            return false;
+        }
+    }
+
+    return undefined;
+}
+
 function cloneData(data) {
     return JSON.parse(JSON.stringify(data));
 }
@@ -663,7 +701,7 @@ function normalizePortalRecord(record) {
         heroTitle: record.hero_title ?? record.heroTitle ?? record.name ?? '',
         heroSubtitle: record.hero_subtitle ?? record.heroSubtitle ?? record.description ?? '',
         bannerImage: record.banner_image ?? record.bannerImage ?? record.hero_image ?? '',
-        chatbotEnabled: Boolean(record.chatbot_enabled ?? record.chatbotEnabled ?? false),
+        chatbotEnabled: parseBooleanFlag(record.chatbot_enabled ?? record.chatbotEnabled) ?? false,
         chatbotName: record.chatbot_name ?? record.chatbotName ?? 'Asistente virtual',
         chatbotWelcome:
             record.chatbot_welcome ?? record.chatbotWelcome ??
@@ -733,9 +771,13 @@ function normalizeSettingsRecords(data) {
                     result.portalBaseUrl = value || '';
                     break;
                 case 'chatbotenabled':
-                case 'chatbot_enabled':
-                    result.chatbotEnabled = value === true || value === 'true' || value === '1';
+                case 'chatbot_enabled': {
+                    const parsed = parseBooleanFlag(value);
+                    if (typeof parsed === 'boolean') {
+                        result.chatbotEnabled = parsed;
+                    }
                     break;
+                }
                 case 'chatbotname':
                 case 'chatbot_name':
                     result.chatbotName = value || '';
@@ -775,8 +817,10 @@ function normalizeSettingsRecords(data) {
                     if (target === 'chatbotFaqs') {
                         result[target] = normalizeChatbotFaqs(record[key]);
                     } else if (target === 'chatbotEnabled') {
-                        const raw = record[key];
-                        result[target] = raw === true || raw === 'true' || raw === '1';
+                        const parsed = parseBooleanFlag(record[key]);
+                        if (typeof parsed === 'boolean') {
+                            result[target] = parsed;
+                        }
                     } else {
                         result[target] = record[key];
                     }

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -122,40 +122,6 @@ const SALE_REQUEST_PENDING_STATUSES = new Set([
     'por atender'
 ]);
 
-function getDefaultSettings() {
-    return cloneData(defaultDashboardState.settings || {});
-}
-
-function mergeSettingsWithDefaults(settings = {}) {
-    const defaults = getDefaultSettings();
-    const merged = { ...defaults };
-
-    if (settings && typeof settings === 'object') {
-        Object.entries(settings).forEach(([key, value]) => {
-            merged[key] = value;
-        });
-    }
-
-    if (!merged.portalBaseUrl) {
-        merged.portalBaseUrl = defaults.portalBaseUrl || '';
-    }
-
-    if (typeof merged.portalBaseUrl === 'string') {
-        merged.portalBaseUrl = merged.portalBaseUrl.trim();
-    }
-
-    if (!merged.themeColor) {
-        merged.themeColor = defaults.themeColor || '#6366f1';
-    }
-
-    merged.chatbotEnabled = Boolean(merged.chatbotEnabled);
-    merged.chatbotName = merged.chatbotName || defaults.chatbotName;
-    merged.chatbotWelcome = merged.chatbotWelcome || defaults.chatbotWelcome;
-    merged.chatbotFaqs = normalizeChatbotFaqs(merged.chatbotFaqs);
-
-    return merged;
-}
-
 function escapeHtml(value) {
     return String(value ?? '')
         .replace(/&/g, '&amp;')
@@ -229,6 +195,13 @@ function parseArrayField(value) {
             .split(',')
             .map((item) => item.trim())
             .filter(Boolean);
+    }
+
+    if (typeof value === 'object') {
+        return Object.values(value).filter(Boolean);
+    }
+
+    return [];
 }
 
 function parseKeywordList(value) {
@@ -288,11 +261,38 @@ function normalizeChatbotFaqs(value) {
         .slice(0, 12);
 }
 
-    if (typeof value === 'object') {
-        return Object.values(value).filter(Boolean);
+function getDefaultSettings() {
+    return cloneData(defaultDashboardState.settings || {});
+}
+
+function mergeSettingsWithDefaults(settings = {}) {
+    const defaults = getDefaultSettings();
+    const merged = { ...defaults };
+
+    if (settings && typeof settings === 'object') {
+        Object.entries(settings).forEach(([key, value]) => {
+            merged[key] = value;
+        });
     }
 
-    return [];
+    if (!merged.portalBaseUrl) {
+        merged.portalBaseUrl = defaults.portalBaseUrl || '';
+    }
+
+    if (typeof merged.portalBaseUrl === 'string') {
+        merged.portalBaseUrl = merged.portalBaseUrl.trim();
+    }
+
+    if (!merged.themeColor) {
+        merged.themeColor = defaults.themeColor || '#6366f1';
+    }
+
+    merged.chatbotEnabled = Boolean(merged.chatbotEnabled);
+    merged.chatbotName = merged.chatbotName || defaults.chatbotName;
+    merged.chatbotWelcome = merged.chatbotWelcome || defaults.chatbotWelcome;
+    merged.chatbotFaqs = normalizeChatbotFaqs(merged.chatbotFaqs);
+
+    return merged;
 }
 
 function parseJsonItems(items) {

--- a/src/sampleData.js
+++ b/src/sampleData.js
@@ -25,7 +25,12 @@ export function getInitialDashboardData() {
             tagline: '',
             themeColor: '#6366f1',
             logoUrl: '',
-            portalBaseUrl: getDefaultPortalBaseUrl()
+            portalBaseUrl: getDefaultPortalBaseUrl(),
+            chatbotEnabled: false,
+            chatbotName: 'Asistente virtual',
+            chatbotWelcome:
+                'Hola, soy tu asistente virtual. Elige una pregunta frecuente o escríbeme para ayudarte.',
+            chatbotFaqs: []
         }
     };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -180,6 +180,38 @@ body.dashboard-visible .page {
     color: #34d399;
 }
 
+.auth-switch {
+    margin-top: 1.25rem;
+    font-size: 0.9rem;
+    color: rgba(226, 232, 240, 0.75);
+    display: flex;
+    gap: 0.35rem;
+    align-items: center;
+    justify-content: center;
+}
+
+.auth-switch-link {
+    background: none;
+    border: none;
+    color: #6366f1;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.9rem;
+    text-decoration: underline;
+}
+
+.auth-switch-link:hover,
+.auth-switch-link:focus-visible {
+    color: #818cf8;
+}
+
+.auth-switch-link:focus-visible {
+    outline: 2px solid #818cf8;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
 .dashboard {
     background: rgba(15, 23, 42, 0.78);
     border-radius: 26px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1296,6 +1296,144 @@ tbody td {
     color: #fca5a5;
 }
 
+.settings-chatbot {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.settings-chatbot legend {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #e2e8f0;
+}
+
+.settings-chatbot-hint {
+    font-size: 0.9rem;
+    color: rgba(148, 163, 184, 0.8);
+    line-height: 1.5;
+}
+
+.settings-chatbot-toggle {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.settings-chatbot-toggle input[type='checkbox'] {
+    width: 48px;
+    height: 24px;
+    accent-color: var(--dashboard-accent, #6366f1);
+}
+
+.chatbot-faq-config {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.chatbot-faq-header h4 {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #e2e8f0;
+}
+
+.chatbot-faq-header p {
+    font-size: 0.85rem;
+    color: rgba(148, 163, 184, 0.75);
+    margin-top: 0.35rem;
+    line-height: 1.4;
+}
+
+.chatbot-faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.chatbot-faq-row {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem;
+    border-radius: 14px;
+    background: rgba(30, 41, 59, 0.65);
+    border: 1px solid rgba(71, 85, 105, 0.4);
+}
+
+.chatbot-faq-main {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.chatbot-faq-answer textarea {
+    min-height: 72px;
+}
+
+.chatbot-faq-remove {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    border: none;
+    background: transparent;
+    color: rgba(248, 250, 252, 0.7);
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+
+.chatbot-faq-remove:hover {
+    color: #fca5a5;
+}
+
+.chatbot-faq-empty {
+    font-size: 0.85rem;
+    color: rgba(148, 163, 184, 0.75);
+    margin: 0;
+}
+
+.chatbot-faq-empty.hidden {
+    display: none;
+}
+
+.chatbot-faq-add {
+    align-self: flex-start;
+    border: 1px dashed rgba(99, 102, 241, 0.6);
+    color: #c7d2fe;
+    background: rgba(79, 70, 229, 0.08);
+    padding: 0.6rem 1rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.chatbot-faq-add:hover {
+    background: rgba(99, 102, 241, 0.18);
+    transform: translateY(-1px);
+}
+
+@media (max-width: 768px) {
+    .settings-chatbot {
+        padding: 1.25rem;
+    }
+
+    .chatbot-faq-main {
+        grid-template-columns: 1fr;
+    }
+
+    .chatbot-faq-remove {
+        top: 0.5rem;
+        right: 0.5rem;
+    }
+}
+
 .clients-table-wrapper,
 .inventory-table-wrapper,
 .inventory-history-table-wrapper {
@@ -2466,6 +2604,224 @@ body.client-portal-body {
     flex-direction: column;
     gap: 0.6rem;
     color: rgba(226, 232, 240, 0.8);
+}
+
+.client-portal-chatbot {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1rem;
+    z-index: 50;
+    --chatbot-accent: var(--portal-public-accent, #6366f1);
+}
+
+.client-portal-chatbot.hidden {
+    display: none;
+}
+
+.client-portal-chatbot-toggle {
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--chatbot-accent);
+    color: #fff;
+    font-size: 1.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 18px 35px rgba(79, 70, 229, 0.35);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.client-portal-chatbot-toggle:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 40px rgba(79, 70, 229, 0.45);
+}
+
+.client-portal-chatbot-window {
+    width: min(360px, 90vw);
+    background: rgba(15, 23, 42, 0.95);
+    border-radius: 18px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.client-portal-chatbot-window[hidden] {
+    display: none;
+}
+
+.client-portal-chatbot-header {
+    padding: 1rem 1.25rem;
+    background: var(--chatbot-accent);
+    color: #fff;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.client-portal-chatbot-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.client-portal-chatbot-subtitle {
+    margin: 0.25rem 0 0;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.client-portal-chatbot-close {
+    border: none;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 1.25rem;
+    cursor: pointer;
+}
+
+.client-portal-chatbot-body {
+    padding: 1rem 1.25rem;
+    background: rgba(15, 23, 42, 0.9);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-height: 280px;
+    overflow: hidden;
+}
+
+.client-portal-chatbot-messages {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.client-portal-chatbot-message {
+    max-width: 80%;
+    padding: 0.7rem 0.9rem;
+    border-radius: 14px;
+    font-size: 0.9rem;
+    line-height: 1.45;
+    background: rgba(30, 41, 59, 0.95);
+    color: #e2e8f0;
+    align-self: flex-start;
+}
+
+.client-portal-chatbot-message.user {
+    background: var(--chatbot-accent);
+    color: #fff;
+    align-self: flex-end;
+}
+
+.client-portal-chatbot-typing {
+    font-size: 0.8rem;
+    color: rgba(148, 163, 184, 0.75);
+    display: none;
+}
+
+.client-portal-chatbot-typing.is-active {
+    display: block;
+}
+
+.client-portal-chatbot-quick {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem 0.5rem;
+    background: rgba(15, 23, 42, 0.9);
+}
+
+.client-portal-chatbot-quick.hidden {
+    display: none;
+}
+
+.client-portal-chatbot-quick-button {
+    border: 1px solid rgba(99, 102, 241, 0.35);
+    background: rgba(79, 70, 229, 0.1);
+    color: #c7d2fe;
+    border-radius: 999px;
+    padding: 0.45rem 0.9rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.client-portal-chatbot-quick-button:hover {
+    background: var(--chatbot-accent);
+    color: #fff;
+    transform: translateY(-1px);
+}
+
+.client-portal-chatbot-form {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.75rem 1.25rem 1.1rem;
+    background: rgba(15, 23, 42, 0.92);
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.client-portal-chatbot-form input {
+    flex: 1;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.7);
+    color: #e2e8f0;
+    padding: 0.65rem 1rem;
+    font-size: 0.9rem;
+}
+
+.client-portal-chatbot-form input:focus-visible {
+    outline: 2px solid rgba(99, 102, 241, 0.55);
+    outline-offset: 2px;
+}
+
+.client-portal-chatbot-send {
+    border: none;
+    background: var(--chatbot-accent);
+    color: #fff;
+    border-radius: 999px;
+    padding: 0.6rem 1.1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.client-portal-chatbot-send:hover {
+    background: rgba(99, 102, 241, 0.9);
+    transform: translateY(-1px);
+}
+
+@media (max-width: 768px) {
+    .client-portal-chatbot {
+        bottom: 1.5rem;
+        right: 1.5rem;
+    }
+
+    .client-portal-chatbot-window {
+        width: min(320px, 92vw);
+    }
+}
+
+@media (max-width: 480px) {
+    .client-portal-chatbot {
+        bottom: 1rem;
+        right: 1rem;
+    }
+
+    .client-portal-chatbot-toggle {
+        width: 3.1rem;
+        height: 3.1rem;
+    }
 }
 
 .client-portal-error {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -60,6 +60,10 @@ create table if not exists public.portals (
     hero_video text,
     hero_media_type text,
     request_intro text,
+    chatbot_enabled boolean default false,
+    chatbot_name text,
+    chatbot_welcome text,
+    chatbot_faqs jsonb default '[]'::jsonb,
     terms text[] default '{}',
     product_ids uuid[] default '{}',
     created_at timestamptz default timezone('utc', now()),
@@ -68,6 +72,12 @@ create table if not exists public.portals (
 
 alter table public.portals
     enable row level security;
+
+alter table public.portals
+    add column if not exists chatbot_enabled boolean default false,
+    add column if not exists chatbot_name text,
+    add column if not exists chatbot_welcome text,
+    add column if not exists chatbot_faqs jsonb default '[]'::jsonb;
 
 drop policy if exists "Portals are publicly readable" on public.portals;
 
@@ -214,7 +224,26 @@ drop policy if exists "Settings are readable by authenticated users" on public.s
 create policy "Settings are readable by authenticated users"
     on public.settings
     for select
-    using (auth.role() = 'authenticated');
+    using (
+        auth.role() = 'authenticated'
+        or (
+            auth.role() = 'anonymous'
+            and key in (
+                'company_name',
+                'company_email',
+                'company_phone',
+                'company_address',
+                'tagline',
+                'theme_color',
+                'logo_url',
+                'portal_base_url',
+                'chatbot_enabled',
+                'chatbot_name',
+                'chatbot_welcome',
+                'chatbot_faqs'
+            )
+        )
+    );
 
 drop policy if exists "Settings are manageable by authenticated users" on public.settings;
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -21,12 +21,16 @@ create table if not exists public.clients (
     status text default 'Activo',
     status_class text,
     notes text,
+    owner_id uuid references auth.users (id) on delete set null,
     created_at timestamptz default timezone('utc', now()),
     updated_at timestamptz default timezone('utc', now())
 );
 
 alter table public.clients
     enable row level security;
+
+alter table public.clients
+    add column if not exists owner_id uuid references auth.users (id) on delete set null;
 
 drop policy if exists "Clients are readable by authenticated users" on public.clients;
 
@@ -66,6 +70,7 @@ create table if not exists public.portals (
     chatbot_faqs jsonb default '[]'::jsonb,
     terms text[] default '{}',
     product_ids uuid[] default '{}',
+    owner_id uuid references auth.users (id) on delete set null,
     created_at timestamptz default timezone('utc', now()),
     updated_at timestamptz default timezone('utc', now())
 );
@@ -77,7 +82,8 @@ alter table public.portals
     add column if not exists chatbot_enabled boolean default false,
     add column if not exists chatbot_name text,
     add column if not exists chatbot_welcome text,
-    add column if not exists chatbot_faqs jsonb default '[]'::jsonb;
+    add column if not exists chatbot_faqs jsonb default '[]'::jsonb,
+    add column if not exists owner_id uuid references auth.users (id) on delete set null;
 
 drop policy if exists "Portals are publicly readable" on public.portals;
 
@@ -112,12 +118,16 @@ create table if not exists public.products (
     portal_id uuid references public.portals (id) on delete set null,
     portal_ids uuid[] default '{}',
     portal_slug text,
+    owner_id uuid references auth.users (id) on delete set null,
     created_at timestamptz default timezone('utc', now()),
     updated_at timestamptz default timezone('utc', now())
 );
 
 alter table public.products
     enable row level security;
+
+alter table public.products
+    add column if not exists owner_id uuid references auth.users (id) on delete set null;
 
 drop policy if exists "Products are publicly readable" on public.products;
 
@@ -150,12 +160,16 @@ create table if not exists public.sales (
     client_email text,
     client_phone text,
     items jsonb default '[]'::jsonb,
+    owner_id uuid references auth.users (id) on delete set null,
     created_at timestamptz default timezone('utc', now()),
     updated_at timestamptz default timezone('utc', now())
 );
 
 alter table public.sales
     enable row level security;
+
+alter table public.sales
+    add column if not exists owner_id uuid references auth.users (id) on delete set null;
 
 drop policy if exists "Sales are readable by authenticated users" on public.sales;
 
@@ -183,12 +197,16 @@ create table if not exists public.inventory_adjustments (
     quantity numeric(12, 2) default 0,
     direction smallint default 1,
     reason text,
+    owner_id uuid references auth.users (id) on delete set null,
     created_at timestamptz default timezone('utc', now()),
     updated_at timestamptz default timezone('utc', now())
 );
 
 alter table public.inventory_adjustments
     enable row level security;
+
+alter table public.inventory_adjustments
+    add column if not exists owner_id uuid references auth.users (id) on delete set null;
 
 drop policy if exists "Inventory adjustments are readable by authenticated users" on public.inventory_adjustments;
 
@@ -273,6 +291,7 @@ create table if not exists public.sale_requests (
     processed_at timestamptz,
     processed_by uuid references auth.users (id) on delete set null,
     sale_id uuid references public.sales (id) on delete set null,
+    owner_id uuid references auth.users (id) on delete set null,
     created_at timestamptz default timezone('utc', now()),
     updated_at timestamptz default timezone('utc', now())
 );
@@ -291,6 +310,9 @@ alter table public.sale_requests
 
 alter table public.sale_requests
     add column if not exists sale_id uuid references public.sales (id) on delete set null;
+
+alter table public.sale_requests
+    add column if not exists owner_id uuid references auth.users (id) on delete set null;
 
 alter table public.sale_requests
     alter column total set default 0,

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -16,6 +16,16 @@ values
     (
         'portal_base_url',
         'https://{REEMPLAZA_CON_TU_DOMINIO}/client-portal.html?portal={{slug}}'
+    ),
+    ('chatbot_enabled', 'true'),
+    ('chatbot_name', 'Asistente virtual'),
+    (
+        'chatbot_welcome',
+        '¡Hola! Soy tu asistente virtual. Puedo ayudarte con preguntas frecuentes sobre el catálogo.'
+    ),
+    (
+        'chatbot_faqs',
+        '[{"question":"¿Cuál es el horario de atención?","answer":"Nuestro horario comercial es de lunes a viernes de 8:00 a.m. a 5:00 p.m.","keywords":["horario","atencion","abren"]},{"question":"¿Cómo funcionan las entregas?","answer":"Coordinamos entregas en todo el país en un plazo de 24 a 48 horas, dependiendo de la zona.","keywords":["entrega","envio","despacho"]},{"question":"¿Qué métodos de pago aceptan?","answer":"Aceptamos transferencias bancarias, SINPE móvil y tarjetas de crédito o débito.","keywords":["pago","pagar","metodo"]}]'
     )
 ON CONFLICT (key) DO UPDATE SET value = excluded.value;
 
@@ -30,6 +40,10 @@ insert into public.portals (
     hero_title,
     hero_subtitle,
     banner_image,
+    chatbot_enabled,
+    chatbot_name,
+    chatbot_welcome,
+    chatbot_faqs,
     terms
 ) values (
     'catalogo-digital',
@@ -41,6 +55,10 @@ insert into public.portals (
     'Explora nuestro catálogo mayorista',
     'Selecciona lo que necesitas y envía tu solicitud en cuestión de minutos.',
     'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1600&q=80',
+    true,
+    'Asistente virtual',
+    '¡Hola! Estoy aquí para ayudarte a navegar el catálogo y resolver tus dudas frecuentes.',
+    '[{"question":"¿Cuál es el horario de atención?","answer":"Trabajamos de lunes a viernes de 8:00 a.m. a 5:00 p.m.","keywords":["horario","hora","atencion"]},{"question":"¿Tienen entregas a todo el país?","answer":"Sí, realizamos entregas a todo el país mediante mensajería especializada.","keywords":["envio","entrega","envían"]},{"question":"¿Cómo puedo contactar a un asesor?","answer":"Escríbenos a ventas@catalogodigital.cr o al +506 8888 8888 y te atenderemos con gusto.","keywords":["contacto","asesor","telefono"]}]'::jsonb,
     ARRAY['Precios sujetos a cambios sin previo aviso.', 'Entregas en todo el país en 48 horas.']
 ) on conflict (slug) do update set
     name = excluded.name,


### PR DESCRIPTION
## Summary
- extend the configuration panel with chatbot controls, including FAQ management stored in Supabase settings
- update the Supabase schema and seed data with chatbot fields and relax the settings policy for public chatbot reads
- add a client portal chatbot widget that loads configuration, renders quick replies, and styles the assistant interface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e82d2de2c0832393de51270800b33e